### PR TITLE
Fix reduce for predecessor.

### DIFF
--- a/include/boost/graph/parallel/properties.hpp
+++ b/include/boost/graph/parallel/properties.hpp
@@ -92,8 +92,10 @@ namespace boost {
     public:
       BOOST_STATIC_CONSTANT(bool, non_default_resolver = true);
 
-      T operator()(T key) const { return key; }
-      T operator()(T key, T, T y) const { return y; }
+      template<typename Key>
+      T operator()(Key key) const { return key; }
+      template<typename Key>
+      T operator()(Key key, T, T y) const { return y; }
     };
   };
 


### PR DESCRIPTION
The assumption was that the predecessor, which is a distributed vertex descriptor, should be
the same as the key. The key is actually a local vertex descriptor, and these two types may
not match.

Signed-off-by: Marcin Zalewski marcin.zalewski@gmail.com
