### PR TITLE
Update mpi_process_group.ipp

### DIFF
--- a/include/boost/graph/distributed/detail/mpi_process_group.ipp
+++ b/include/boost/graph/distributed/detail/mpi_process_group.ipp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <queue>
 #include <stack>
+#include <list>
 #include <boost/graph/distributed/detail/tag_allocator.hpp>
 #include <stdio.h>
 


### PR DESCRIPTION
I tried to compile Boost.MPI on Windows 8 with `toolset=msvc-12.0` (Visual Studio 2013).
Building this library failed for me without the proposed fix.
