### PR TITLE
Added a presumably missing include directive.

### DIFF
--- a/include/boost/graph/distributed/detail/mpi_process_group.ipp
+++ b/include/boost/graph/distributed/detail/mpi_process_group.ipp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <queue>
 #include <stack>
+#include <list>
 #include <boost/graph/distributed/detail/tag_allocator.hpp>
 #include <stdio.h>
 


### PR DESCRIPTION
So, I tried to compile Boost on Windows 8 with `toolset=msvc-12.0` (Visual Studio 2013).
Building the graph_parallel libraries (`boost_graph_parallel-vc120-mt-1_57.dll` etc.) succeeded for me only with the proposed fix.
