### PR TITLE
Fix for MSVC warning

### DIFF
--- a/include/boost/graph/distributed/adjlist/serialization.hpp
+++ b/include/boost/graph/distributed/adjlist/serialization.hpp
@@ -78,7 +78,7 @@ namespace detail { namespace parallel
 
   inline bool is_digit(char c)
   {
-      return (bool)std::isdigit(c);
+      return std::isdigit(c) != 0;
   }
 
   inline std::vector<int> 


### PR DESCRIPTION
"warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)"