### PR TITLE
Remove deprecated std::binary_function

### DIFF
--- a/include/boost/graph/distributed/crauser_et_al_shortest_paths.hpp
+++ b/include/boost/graph/distributed/crauser_et_al_shortest_paths.hpp
@@ -95,8 +95,10 @@ namespace detail {
   template<typename Vertex, typename DistanceMap, typename MinInWeightMap,
            typename Combine, typename Compare>
   struct min_in_distance_compare
-    : std::binary_function<Vertex, Vertex, bool>
   {
+    typedef Vertex first_argument_type;
+    typedef Vertex second_argument_type;
+    typedef bool result_type;
     min_in_distance_compare(DistanceMap d, MinInWeightMap m,
                             Combine combine, Compare compare)
       : distance_map(d), min_in_weight(m), combine(combine),
@@ -120,8 +122,10 @@ namespace detail {
   template<typename Vertex, typename DistanceMap, typename MinOutWeightMap,
            typename Combine, typename Compare>
   struct min_out_distance_compare
-    : std::binary_function<Vertex, Vertex, bool>
   {
+    typedef Vertex first_argument_type;
+    typedef Vertex second_argument_type;
+    typedef bool result_type;
     min_out_distance_compare(DistanceMap d, MinOutWeightMap m,
                              Combine combine, Compare compare)
       : distance_map(d), min_out_weight(m), combine(combine),

--- a/include/boost/graph/parallel/algorithm.hpp
+++ b/include/boost/graph/parallel/algorithm.hpp
@@ -16,7 +16,6 @@
 #include <boost/optional.hpp>
 #include <boost/config.hpp> // for BOOST_STATIC_CONSTANT
 #include <vector>
-#include <functional>
 
 namespace boost { namespace parallel {
   template<typename BinaryOp>
@@ -26,20 +25,29 @@ namespace boost { namespace parallel {
   };
 
   template<typename T>
-  struct minimum : std::binary_function<T, T, T>
+  struct minimum
   {
+    typedef T first_argument_type;
+    typedef T second_argument_type;
+    typedef T result_type;
     const T& operator()(const T& x, const T& y) const { return x < y? x : y; }
   };
 
   template<typename T>
-  struct maximum : std::binary_function<T, T, T>
+  struct maximum
   {
+    typedef T first_argument_type;
+    typedef T second_argument_type;
+    typedef T result_type;
     const T& operator()(const T& x, const T& y) const { return x < y? y : x; }
   };
 
   template<typename T>
-  struct sum : std::binary_function<T, T, T>
+  struct sum
   {
+    typedef T first_argument_type;
+    typedef T second_argument_type;
+    typedef T result_type;
     const T operator()(const T& x, const T& y) const { return x + y; }
   };
 


### PR DESCRIPTION
`std::binary_function` was removed in C++17 and is no longer available while compiling with MS Visual Studio 2017