### PR TITLE
Replace std::swap overload for outgoing messages

### DIFF
--- a/include/boost/graph/distributed/mpi_process_group.hpp
+++ b/include/boost/graph/distributed/mpi_process_group.hpp
@@ -614,8 +614,6 @@ public:
   int size;
 };
 
-
-
 inline mpi_process_group::process_id_type 
 process_id(const mpi_process_group& pg)
 { return pg.rank; }
@@ -686,6 +684,15 @@ template<typename T>
 void
 broadcast(const mpi_process_group& pg, T& val, 
           mpi_process_group::process_id_type root);
+
+
+/// optimized swap for outgoing messages
+inline void
+swap(mpi_process_group::outgoing_messages& x,
+     mpi_process_group::outgoing_messages& y)
+{
+  x.swap(y);
+}
 
 
 /*******************************************************************
@@ -789,18 +796,6 @@ namespace boost { namespace mpi {
     template<>
     struct is_mpi_datatype<boost::graph::distributed::mpi_process_group::message_header> : mpl::true_ { };
 } } // end namespace boost::mpi
-
-namespace std {
-/// optimized swap for outgoing messages
-inline void 
-swap(boost::graph::distributed::mpi_process_group::outgoing_messages& x,
-     boost::graph::distributed::mpi_process_group::outgoing_messages& y)
-{
-  x.swap(y);
-}
-
-
-}
 
 BOOST_CLASS_IMPLEMENTATION(boost::graph::distributed::mpi_process_group::outgoing_messages,object_serializable)
 BOOST_CLASS_TRACKING(boost::graph::distributed::mpi_process_group::outgoing_messages,track_never)


### PR DESCRIPTION
Adding overloads to namespace std is undefined behaviour. The correct
way to customize swap is to provide an overload in the type's own
namespace, so it will be found by ADL.