### PR TITLE
Use uncaught_exceptions from Boost.Core to avoid C++17 warnings

### DIFF
--- a/include/boost/graph/distributed/adjacency_list.hpp
+++ b/include/boost/graph/distributed/adjacency_list.hpp
@@ -15,6 +15,7 @@
 #error "Parallel BGL files should not be included unless <boost/graph/use_mpi.hpp> has been included"
 #endif
 
+#include <boost/core/uncaught_exceptions.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -2285,7 +2286,7 @@ namespace boost {
     /// If this vertex has already been created or will be created by
     /// someone else, or if someone threw an exception, we will not
     /// create the vertex now.
-    if (committed || std::uncaught_exception())
+    if (committed || boost::core::uncaught_exceptions() > 0)
       return;
 
     committed = true;
@@ -2398,7 +2399,7 @@ namespace boost {
     /// If this edge has already been created or will be created by
     /// someone else, or if someone threw an exception, we will not
     /// create the edge now.
-    if (committed || std::uncaught_exception())
+    if (committed || boost::core::uncaught_exceptions() > 0)
       return;
 
     committed = true;
@@ -2583,7 +2584,7 @@ namespace boost {
     /// If this edge has already been created or will be created by
     /// someone else, or if someone threw an exception, we will not
     /// create the edge now.
-    if (this->committed || std::uncaught_exception())
+    if (this->committed || boost::core::uncaught_exceptions() > 0)
       return;
 
     this->committed = true;

--- a/include/boost/graph/distributed/named_graph.hpp
+++ b/include/boost/graph/distributed/named_graph.hpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <boost/assert.hpp>
+#include <boost/core/uncaught_exceptions.hpp>
 #include <boost/graph/named_graph.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/variant.hpp>
@@ -376,7 +377,7 @@ BGL_NAMED_GRAPH::lazy_add_vertex::~lazy_add_vertex()
   /// If this vertex has already been created or will be created by
   /// someone else, or if someone threw an exception, we will not
   /// create the vertex now.
-  if (committed || std::uncaught_exception())
+  if (committed || boost::core::uncaught_exceptions() > 0)
     return;
 
   committed = true;
@@ -486,7 +487,7 @@ BGL_NAMED_GRAPH::lazy_add_edge::~lazy_add_edge()
   /// If this edge has already been created or will be created by
   /// someone else, or if someone threw an exception, we will not
   /// create the edge now.
-  if (committed || std::uncaught_exception())
+  if (committed || boost::core::uncaught_exceptions() > 0)
     return;
 
   committed = true;
@@ -682,7 +683,7 @@ BGL_NAMED_GRAPH::lazy_add_edge_with_property::~lazy_add_edge_with_property()
   /// If this edge has already been created or will be created by
   /// someone else, or if someone threw an exception, we will not
   /// create the edge now.
-  if (committed || std::uncaught_exception())
+  if (committed || boost::core::uncaught_exceptions() > 0)
     return;
 
   committed = true;


### PR DESCRIPTION
In C++17, `std::uncaught_exception` is deprecated in favor of `std::uncaught_exceptions`. Use portable `uncaught_exceptions` implementation from Boost.Core, which is also available for C++03.

This fixes gcc 8 warnings about using deprecated features in C++17 mode.
