### PR TITLE
Remove mentions of bsp_process_group from docs

### DIFF
--- a/doc/distributed_adjacency_list.rst
+++ b/doc/distributed_adjacency_list.rst
@@ -58,7 +58,7 @@ vertices or edges of the graph.
 
   using namespace boost;
   typedef adjacency_list<vecS, 
-                         distributedS<parallel::mpi::bsp_process_group, vecS>,
+                         distributedS<graph::distributed::mpi_process_group, vecS>,
                          directedS> 
     Graph;
 
@@ -120,7 +120,7 @@ respectively:
 ::
 
   typedef adjacency_list<vecS, 
-                         distributedS<parallel::mpi::bsp_process_group, vecS>,
+                         distributedS<graph::distributed::mpi_process_group, vecS>,
                          directedS,
                          City, Highway> 
     RoadMap;

--- a/doc/html/distributed_adjacency_list.html
+++ b/doc/html/distributed_adjacency_list.html
@@ -79,7 +79,7 @@ vertices or edges of the graph.</p>
 <pre class="literal-block">
 using namespace boost;
 typedef adjacency_list&lt;vecS,
-                       distributedS&lt;parallel::mpi::bsp_process_group, vecS&gt;,
+                       distributedS&lt;graph::distributed::mpi_process_group, vecS&gt;,
                        directedS&gt;
   Graph;
 </pre>
@@ -135,7 +135,7 @@ struct Highway {
 respectively:</p>
 <pre class="literal-block">
 typedef adjacency_list&lt;vecS,
-                       distributedS&lt;parallel::mpi::bsp_process_group, vecS&gt;,
+                       distributedS&lt;graph::distributed::mpi_process_group, vecS&gt;,
                        directedS,
                        City, Highway&gt;
   RoadMap;


### PR DESCRIPTION
parallel::mpi::bsp_process_group does not exist anymore but is still mentioned in docs.