### PR TITLE
Expect either boost::optional or std::optional from Boost.MPI

### DIFF
--- a/include/boost/graph/distributed/detail/mpi_process_group.ipp
+++ b/include/boost/graph/distributed/detail/mpi_process_group.ipp
@@ -505,7 +505,7 @@ void do_oob_receive(mpi_process_group const& self,
   status = self.impl_->comm.probe(source, tag);
 
 #if BOOST_VERSION >= 103600
-  int size = status.count<boost::mpi::packed>().get();
+  int size = status.count<boost::mpi::packed>().value();
 #else
   int size;
   MPI_Status& mpi_status = status;
@@ -959,7 +959,7 @@ receive_oob(const mpi_process_group& pg,
   std::pair<boost::mpi::communicator, int> actual
     = pg.actual_communicator_and_tag(tag, block);
 
-  boost::optional<boost::mpi::status> status;
+  boost::mpi::optional<boost::mpi::status> status;
   do {
     status = actual.first.iprobe(source, actual.second);
     if (!status)
@@ -972,7 +972,7 @@ receive_oob(const mpi_process_group& pg,
   boost::mpi::packed_iarchive in(actual.first);
 
 #if BOOST_VERSION >= 103600
-  in.resize(status->count<boost::mpi::packed>().get());
+  in.resize(status->count<boost::mpi::packed>().value());
 #else
   int size;
   MPI_Status mpi_status = *status;

--- a/src/mpi_process_group.cpp
+++ b/src/mpi_process_group.cpp
@@ -725,7 +725,7 @@ void mpi_process_group::receive_batch(boost::mpi::status& status) const
     
   // Determine how big the receive buffer should be
 #if BOOST_VERSION >= 103600
-  int size = status.count<boost::mpi::packed>().get();
+  int size = status.count<boost::mpi::packed>().value();
 #else
   int size;
   MPI_Status mpi_status(status);
@@ -978,7 +978,7 @@ poll(bool wait, int block, bool synchronizing) const
     impl_->trigger_context = trc_out_of_band;
 
   //wait = false;
-  optional<boost::mpi::status> status;
+  boost::mpi::optional<boost::mpi::status> status;
   bool finished=false;
   optional<std::pair<int, int> > result;
   do {
@@ -993,14 +993,14 @@ poll(bool wait, int block, bool synchronizing) const
 
     if (status) { // we have a message
       // Decode the message
-      std::pair<int, int> decoded = decode_tag(status.get().tag());
-      if (maybe_emit_receive(status.get().source(), status.get().tag()))
+      std::pair<int, int> decoded = decode_tag(status.value().tag());
+      if (maybe_emit_receive(status.value().source(), status.value().tag()))
         // We received the message out-of-band; poll again
         finished = false;
       else if (decoded.first == (block == -1 ? my_block_number() : block)) {
         // This message is for us, but not through a trigger. Return
         // the decoded message.
-        result = std::make_pair(status.get().source(), decoded.second);
+        result = std::make_pair(status.value().source(), decoded.second);
       // otherwise we didn't match any message we know how to deal with, so
       // pretend no message exists.
         finished = true;


### PR DESCRIPTION
This is a 'fix' for https://github.com/boostorg/graph_parallel/issues/39. 

It assume Boost MPI develop version https://github.com/boostorg/mpi/commit/2eed4e7c7ac37c335f1c5175e6c7fc3f9b4e7347